### PR TITLE
1.3 compatibility

### DIFF
--- a/package.js
+++ b/package.js
@@ -9,6 +9,7 @@ Package.onUse(function (api) {
   api.versionsFrom('METEOR@1.0');
 
   api.use([
+    'blaze-html-templates@1.0.1',
     'orionjs:base@1.0.0',
     'orionjs:attributes@1.0.0',
     'bootstrp:tagsinput@0.5.0'


### PR DESCRIPTION
Doesn't work without 'blaze-html-templates@1.0.1' in api.use on Meteor 1.3
